### PR TITLE
Remove duplicate sysprop adb secure assignment

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -2,7 +2,6 @@ ro.display.series=Moto G60
 ro.product.board=sm6150
 ro.board.platform=sm6150
 vendor.gatekeeper.disable_spu=true
-ro.adb.secure=0
 fbe.metadata.wrappedkey=true
 ro.crypto.volume.filenames_mode=aes-256-cts
 ro.vendor.qti.va_aosp.support=1


### PR DESCRIPTION
Fixes:
error: found duplicate sysprop assignments